### PR TITLE
Improved export performance (especially when using shaders) and decreased vram utilization

### DIFF
--- a/src/main/java/com/moulberry/flashback/exporting/SaveableFramebuffer.java
+++ b/src/main/java/com/moulberry/flashback/exporting/SaveableFramebuffer.java
@@ -1,6 +1,7 @@
 package com.moulberry.flashback.exporting;
 
 import com.mojang.blaze3d.pipeline.MainTarget;
+import com.mojang.blaze3d.pipeline.RenderTarget;
 import com.mojang.blaze3d.platform.NativeImage;
 import org.jetbrains.annotations.Nullable;
 import org.lwjgl.opengl.GL30C;
@@ -10,35 +11,17 @@ import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 
 public class SaveableFramebuffer implements AutoCloseable {
-
-    private MainTarget framebuffer;
     private int pboId;
     public @Nullable FloatBuffer audioBuffer;
 
     private boolean isDownloading = false;
 
     public SaveableFramebuffer() {
-        this.framebuffer = null;
         this.pboId = -1;
     }
 
-    public boolean isDownloading() {
-        return isDownloading;
-    }
 
-    public MainTarget getFramebuffer(int width, int height) {
-        if (this.isDownloading) {
-            throw new IllegalStateException("Can't get the framebuffer for rendering while still downloading");
-        }
-
-        if (this.framebuffer == null) {
-            this.framebuffer = new MainTarget(width, height);
-        }
-
-        return this.framebuffer;
-    }
-
-    public void startDownload(int width, int height) {
+    public void startDownload(RenderTarget framebuffer, int width, int height) {
         if (this.isDownloading) {
             throw new IllegalStateException("Can't start downloading while already downloading");
         }
@@ -52,13 +35,13 @@ public class SaveableFramebuffer implements AutoCloseable {
             GL30C.glBindBuffer(GL30C.GL_PIXEL_PACK_BUFFER, 0);
         }
 
-        this.framebuffer.bindWrite(true);
+        framebuffer.bindWrite(true);
 
         GL30C.glBindBuffer(GL30C.GL_PIXEL_PACK_BUFFER, this.pboId);
         GL30C.glReadPixels(0, 0, width, height, GL30C.GL_RGBA, GL30C.GL_UNSIGNED_BYTE, 0);
         GL30C.glBindBuffer(GL30C.GL_PIXEL_PACK_BUFFER, 0);
 
-        this.framebuffer.unbindWrite();
+        framebuffer.unbindWrite();
     }
 
     public NativeImage finishDownload(int width, int height) {
@@ -79,15 +62,6 @@ public class SaveableFramebuffer implements AutoCloseable {
         // Copy bytes
         MemoryUtil.memCopy(MemoryUtil.memAddress(buffer), nativeImage.pixels, nativeImage.size);
 
-//        for (int y = 0; y < nativeImage.getHeight(); ++y) {
-//            for (int x = 0; x < nativeImage.getWidth(); ++x) {
-//                int rgba = nativeImage.getPixelRGBA(x, y);
-//                nativeImage.setPixelRGBA(x, y, (rgba & 0xFFFFFF) | (80 << NativeImage.Format.RGBA.alphaOffset()));
-//            }
-//        }
-
-        nativeImage.flipY();
-
         GL30C.glUnmapBuffer(GL30C.GL_PIXEL_PACK_BUFFER);
         GL30C.glBindBuffer(GL30C.GL_PIXEL_PACK_BUFFER, 0);
 
@@ -95,10 +69,6 @@ public class SaveableFramebuffer implements AutoCloseable {
     }
 
     public void close() {
-        if (this.framebuffer != null) {
-            this.framebuffer.destroyBuffers();
-            this.framebuffer = null;
-        }
         if (this.pboId != -1) {
             GL30C.glDeleteBuffers(this.pboId);
             this.pboId = -1;

--- a/src/main/java/com/moulberry/flashback/exporting/SaveableFramebufferQueue.java
+++ b/src/main/java/com/moulberry/flashback/exporting/SaveableFramebufferQueue.java
@@ -1,8 +1,19 @@
 package com.moulberry.flashback.exporting;
 
+import com.mojang.blaze3d.pipeline.RenderTarget;
+import com.mojang.blaze3d.pipeline.TextureTarget;
+import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.platform.NativeImage;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.BufferBuilder;
+import com.mojang.blaze3d.vertex.BufferUploader;
+import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import com.mojang.blaze3d.vertex.VertexFormat;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.ShaderInstance;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 import java.util.ArrayList;
@@ -18,12 +29,22 @@ public class SaveableFramebufferQueue implements AutoCloseable {
     private final List<SaveableFramebuffer> available = new ArrayList<>();
     private final List<SaveableFramebuffer> waiting = new ArrayList<>();
 
+    private final RenderTarget flipbuffer;
+    private final ShaderInstance flipShader;
+
     public SaveableFramebufferQueue(int width, int height) {
         this.width = width;
         this.height = height;
+        this.flipbuffer = new TextureTarget(width, height, false, false);
 
         for (int i = 0; i < CAPACITY; i++) {
             this.available.add(new SaveableFramebuffer());
+        }
+
+        try {
+            this.flipShader = new ShaderInstance(Minecraft.getInstance().getResourceManager(), "blit_screen_flip", DefaultVertexFormat.BLIT_SCREEN);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
     }
 
@@ -34,8 +55,35 @@ public class SaveableFramebufferQueue implements AutoCloseable {
         return this.available.removeFirst();
     }
 
-    public void startDownload(SaveableFramebuffer texture) {
-        texture.startDownload(this.width, this.height);
+    private void blitFlip(RenderTarget src) {
+        GlStateManager._colorMask(true, true, true, true);
+        GlStateManager._disableDepthTest();
+        GlStateManager._depthMask(false);
+        GlStateManager._viewport(0, 0, src.width, src.height);
+        GlStateManager._disableBlend();
+        RenderSystem.disableCull();
+
+        this.flipbuffer.bindWrite(true);
+        this.flipShader.setSampler("DiffuseSampler", src.colorTextureId);
+        this.flipShader.apply();
+        BufferBuilder bufferBuilder = RenderSystem.renderThreadTesselator().begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.BLIT_SCREEN);
+        bufferBuilder.addVertex(0.0F, 1.0F, 0.0F);
+        bufferBuilder.addVertex(1.0F, 1.0F, 0.0F);
+        bufferBuilder.addVertex(1.0F, 0.0F, 0.0F);
+        bufferBuilder.addVertex(0.0F, 0.0F, 0.0F);
+        BufferUploader.draw(bufferBuilder.buildOrThrow());
+        this.flipShader.clear();
+
+        GlStateManager._depthMask(true);
+        GlStateManager._colorMask(true, true, true, true);
+        RenderSystem.enableCull();
+    }
+
+    public void startDownload(RenderTarget target, SaveableFramebuffer texture) {
+        //Do an inline flip
+        this.blitFlip(target);
+
+        texture.startDownload(this.flipbuffer, this.width, this.height);
         this.waiting.add(texture);
     }
 
@@ -70,6 +118,8 @@ public class SaveableFramebufferQueue implements AutoCloseable {
         }
         this.waiting.clear();
         this.available.clear();
+        this.flipbuffer.destroyBuffers();
+        this.flipShader.close();
     }
 
 

--- a/src/main/resources/assets/minecraft/shaders/core/blit_screen_flip.json
+++ b/src/main/resources/assets/minecraft/shaders/core/blit_screen_flip.json
@@ -1,0 +1,9 @@
+{
+    "vertex": "blit_screen_flip",
+    "fragment": "blit_screen",
+    "samplers": [
+        { "name": "DiffuseSampler" }
+    ],
+    "uniforms": [
+    ]
+}

--- a/src/main/resources/assets/minecraft/shaders/core/blit_screen_flip.vsh
+++ b/src/main/resources/assets/minecraft/shaders/core/blit_screen_flip.vsh
@@ -1,0 +1,11 @@
+#version 150
+
+in vec3 Position;
+
+out vec2 texCoord;
+
+void main() {
+    vec2 screenPos = vec2(Position.x, 1-Position.y) * 2.0 - 1.0;
+    gl_Position = vec4(screenPos.x, screenPos.y, 1.0, 1.0);
+    texCoord = Position.xy;
+}


### PR DESCRIPTION
Removed NativeImage.flipY, and moved image flipping to gpu
Removed un-needed framebuffers
Removed multi-framebuffer async path and made everything "async"

(I give my full permission for Moulberry to use, modify or otherwise do whatever they want or see fit to my changes)