### PR TITLE
Fix newer versions of MixinSquared breaking older versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ dependencies {
 //    shadow(implementation("org.jcodec:jcodec-javase:0.2.5"))
 //    shadow(implementation("io.humble:humble-video-all:0.3.0"))
 
-    include(implementation(annotationProcessor("com.bawnorton.mixinsquared:mixinsquared-fabric:0.2.0-beta.6")))
+    include(implementation(annotationProcessor("com.github.bawnorton:mixinsquared-fabric:0.2.0-beta.6")))
 
 	shadow(implementation("org.bytedeco:javacv-platform:1.5.10") {
 		exclude group: "org.bytedeco", module: "artoolkitplus"

--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ dependencies {
 //    shadow(implementation("org.jcodec:jcodec-javase:0.2.5"))
 //    shadow(implementation("io.humble:humble-video-all:0.3.0"))
 
-    include(implementation(annotationProcessor("com.github.bawnorton:mixinsquared-fabric:0.2.0-beta.6")))
+    include(implementation(annotationProcessor("com.github.bawnorton.mixinsquared:mixinsquared-fabric:0.2.0-beta.6")))
 
 	shadow(implementation("org.bytedeco:javacv-platform:1.5.10") {
 		exclude group: "org.bytedeco", module: "artoolkitplus"


### PR DESCRIPTION
MixinSquared migrated from jitpack to my own maven when 0.2.0-beta.5 released, I did not know at the time that this would break compatibility with older versions of MixinSquared as the maven group changed from `com.github.bawnorton` to `com.bawnorton` causing mod loaders to think they were different mods. 

This PR reverts that change to allow for compatibility with older versions of MixinSquared.

 I aplogize for the inconvenience, I was not aware of the implications of this change.

_This PR was generated automatically_