### PR TITLE
Drop inventory packets that do not affect hotbar

### DIFF
--- a/src/main/java/com/moulberry/flashback/playback/ReplayGamePacketHandler.java
+++ b/src/main/java/com/moulberry/flashback/playback/ReplayGamePacketHandler.java
@@ -1125,11 +1125,6 @@ public class ReplayGamePacketHandler implements ClientGamePacketListener {
         Entity entity = this.level().getEntity(this.localPlayerId);
         if (entity instanceof Player player) {
             int slot = clientboundSetPlayerInventoryPacket.slot();
-            if (slot > 9) {
-                // Tried setting on slot in the inventory, not in the hotbar, continuing would result in index out of bounds crash
-                return;
-            }
-
             ItemStack itemStack = clientboundSetPlayerInventoryPacket.contents();
             player.getInventory().setItem(slot, itemStack);
 

--- a/src/main/java/com/moulberry/flashback/playback/ReplayGamePacketHandler.java
+++ b/src/main/java/com/moulberry/flashback/playback/ReplayGamePacketHandler.java
@@ -1125,6 +1125,11 @@ public class ReplayGamePacketHandler implements ClientGamePacketListener {
         Entity entity = this.level().getEntity(this.localPlayerId);
         if (entity instanceof Player player) {
             int slot = clientboundSetPlayerInventoryPacket.slot();
+            if (slot > 9) {
+                // Tried setting on slot in the inventory, not in the hotbar, continuing would result in index out of bounds crash
+                return;
+            }
+
             ItemStack itemStack = clientboundSetPlayerInventoryPacket.contents();
             player.getInventory().setItem(slot, itemStack);
 

--- a/src/main/java/com/moulberry/flashback/record/Recorder.java
+++ b/src/main/java/com/moulberry/flashback/record/Recorder.java
@@ -804,6 +804,14 @@ public class Recorder {
             }
         }
 
+        // We are only interested in recording the hotbar inventory packets, anything other can be dropped.
+        if (packet instanceof ClientboundSetPlayerInventoryPacket inventoryPacket) {
+            int inventorySlot = inventoryPacket.slot();
+            if (inventorySlot > 9) {
+                return;
+            }
+        }
+
         if (IgnoredPacketSet.isIgnored(packet)) {
             return;
         }


### PR DESCRIPTION
Whenever having the hotbar record option enabled and then replaying and the player would set any item on different slot than hotbar, it would result in index out of bounds crash.

I have fixed this and tested this by adding simple if check, that checks if the slot is larger than 9 (because then it's not hotbar).
