### PR TITLE
Fix crash with Simple Voice Chat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ repositories {
 		}
 	}
     maven { url = "https://maven.bawnorton.com/releases" }
+	maven { url = "https://maven.maxhenkel.de/repository/public" }
 }
 
 loom {
@@ -69,7 +70,8 @@ dependencies {
     modCompileOnly("maven.modrinth:sodium:RncWhTxD")
     modCompileOnly("maven.modrinth:iris:kuOV4Ece")
     modCompileOnly("maven.modrinth:bobby:2cuVyTav")
-    modCompileOnly("maven.modrinth:simple-voice-chat:4Zzq92HE")
+    modCompileOnly("maven.modrinth:simple-voice-chat:fabric-1.21.4-2.5.27")
+	compileOnly("de.maxhenkel.voicechat:voicechat-api:2.5.0")
     modCompileOnly("maven.modrinth:replaymod:NtlpUQgI")
     modCompileOnly("maven.modrinth:modmenu:xhN1IvHi")
 


### PR DESCRIPTION
This is related to https://github.com/henkelmax/simple-voice-chat/issues/765.

The latest update of the Simple Voice Chat mod causes flashback to crash, since some internals have changed.
It is always recommended to use the API instead of the mod, since the API is guaranteed to never break between updates.
I know there are some things that are needed for Flashback that are not present in the API, but I changed how the `VoicechatClientApi` instance is obtained, since this is possible using the API.
I also added the API as an import, since that provides javadocs.

Thanks for making such an awesome mod!