### PR TITLE
Fix Simple Voice Chat disconnect symbol showing in replays

### DIFF
--- a/src/main/java/com/moulberry/flashback/mixin/compat/voice_chat/MixinVoiceChatClientPlayerStateManager.java
+++ b/src/main/java/com/moulberry/flashback/mixin/compat/voice_chat/MixinVoiceChatClientPlayerStateManager.java
@@ -1,0 +1,24 @@
+package com.moulberry.flashback.mixin.compat.voice_chat;
+
+import com.moulberry.flashback.Flashback;
+import com.moulberry.mixinconstraints.annotations.IfModLoaded;
+import de.maxhenkel.voicechat.voice.client.ClientPlayerStateManager;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@IfModLoaded("voicechat")
+@Pseudo
+@Mixin(value = ClientPlayerStateManager.class, remap = false)
+public class MixinVoiceChatClientPlayerStateManager {
+
+    @Inject(method = "isPlayerDisconnected", at = @At("HEAD"), cancellable = true)
+    public void isPlayerDisconnected(CallbackInfoReturnable<Boolean> cir) {
+        if (Flashback.isInReplay()) {
+            cir.setReturnValue(false);
+        }
+    }
+
+}

--- a/src/main/resources/flashback.mixins.json
+++ b/src/main/resources/flashback.mixins.json
@@ -64,6 +64,7 @@
     "compat.voice_chat.MixinVoiceChatClientVoicechat",
     "compat.voice_chat.MixinVoiceChatRenderEvents",
     "compat.voice_chat.MixinVoiceChatSoundManager",
+    "compat.voice_chat.MixinVoiceChatClientPlayerStateManager",
     "playback.MixinAttributeInstance",
     "playback.MixinBoat",
     "playback.MixinChunkHolder",


### PR DESCRIPTION
This patch fixes the annoying issue that the Simple Voice Chat plug symbol is constantly shown above all players, even if they have  the mod installed.