### PR TITLE
Add affirmation option to Render Filter Oath

### DIFF
--- a/src/main/java/com/moulberry/flashback/editor/ui/windows/RenderFilterWindow.java
+++ b/src/main/java/com/moulberry/flashback/editor/ui/windows/RenderFilterWindow.java
@@ -55,7 +55,7 @@ public class RenderFilterWindow {
             if (!config.signedRenderFilter) {
                 String name = Minecraft.getInstance().getGameProfile().getName();
                 ImGui.pushTextWrapPos(300);
-                ImGui.textWrapped("I, " + name + ", do solemnly swear that I will not toggle something off in the 'Render Filter' menu and then later ask in Flashback support why the entity is not being rendered.");
+                ImGui.textWrapped("I, " + name + ", do solemnly swear (or affirm) that I will not toggle something off in the 'Render Filter' menu and then later ask in Flashback support why the entity is not being rendered.");
                 if (ImGui.checkbox("Signed, " + name + ".", false)) {
                     config.signedRenderFilter = true;
                     config.delayedSaveToDefaultFolder();


### PR DESCRIPTION
An [Affirmation](https://en.wikipedia.org/wiki/Affirmation_(law)) is an alternative for those who object for some reason, religious or other, to swearing an oath. This pull request adds in the text "(or affirm)" into the Render Filter Oath, allowing for it to also be taken as an affirmation. The way the affirmation opinion is formatted here is consistent with the way affirmation options are generally formatted in US oaths of office.