### PR TITLE
Add gamma override UI and keyframe type

### DIFF
--- a/src/main/java/com/moulberry/flashback/Flashback.java
+++ b/src/main/java/com/moulberry/flashback/Flashback.java
@@ -24,6 +24,7 @@ import com.moulberry.flashback.keyframe.types.CameraShakeKeyframeType;
 import com.moulberry.flashback.keyframe.types.TrackEntityKeyframeType;
 import com.moulberry.flashback.keyframe.types.FOVKeyframeType;
 import com.moulberry.flashback.keyframe.types.FreezeKeyframeType;
+import com.moulberry.flashback.keyframe.types.GammaKeyframeType;
 import com.moulberry.flashback.keyframe.types.SpeedKeyframeType;
 import com.moulberry.flashback.keyframe.types.TimeOfDayKeyframeType;
 import com.moulberry.flashback.keyframe.types.TimelapseKeyframeType;
@@ -246,6 +247,7 @@ public class Flashback implements ModInitializer, ClientModInitializer {
         KeyframeRegistry.register(TrackEntityKeyframeType.INSTANCE);
         KeyframeRegistry.register(CameraShakeKeyframeType.INSTANCE);
         KeyframeRegistry.register(FOVKeyframeType.INSTANCE);
+        KeyframeRegistry.register(GammaKeyframeType.INSTANCE);
         KeyframeRegistry.register(SpeedKeyframeType.INSTANCE);
         KeyframeRegistry.register(TimelapseKeyframeType.INSTANCE);
         KeyframeRegistry.register(TimeOfDayKeyframeType.INSTANCE);

--- a/src/main/java/com/moulberry/flashback/FlashbackGson.java
+++ b/src/main/java/com/moulberry/flashback/FlashbackGson.java
@@ -13,6 +13,7 @@ import com.moulberry.flashback.keyframe.impl.CameraShakeKeyframe;
 import com.moulberry.flashback.keyframe.impl.TrackEntityKeyframe;
 import com.moulberry.flashback.keyframe.impl.FOVKeyframe;
 import com.moulberry.flashback.keyframe.impl.FreezeKeyframe;
+import com.moulberry.flashback.keyframe.impl.GammaKeyframe;
 import com.moulberry.flashback.keyframe.impl.TickrateKeyframe;
 import com.moulberry.flashback.keyframe.impl.TimeOfDayKeyframe;
 import com.moulberry.flashback.keyframe.impl.TimelapseKeyframe;
@@ -44,6 +45,7 @@ public class FlashbackGson {
             .registerTypeAdapter(CameraOrbitKeyframe.class, new CameraOrbitKeyframe.TypeAdapter())
             .registerTypeAdapter(TrackEntityKeyframe.class, new TrackEntityKeyframe.TypeAdapter())
             .registerTypeAdapter(FOVKeyframe.class, new FOVKeyframe.TypeAdapter())
+            .registerTypeAdapter(GammaKeyframe.class, new GammaKeyframe.TypeAdapter())
             .registerTypeAdapter(CameraShakeKeyframe.class, new CameraShakeKeyframe.TypeAdapter())
             .registerTypeAdapter(TickrateKeyframe.class, new TickrateKeyframe.TypeAdapter())
             .registerTypeAdapter(TimelapseKeyframe.class, new TimelapseKeyframe.TypeAdapter())

--- a/src/main/java/com/moulberry/flashback/configuration/FlashbackConfig.java
+++ b/src/main/java/com/moulberry/flashback/configuration/FlashbackConfig.java
@@ -112,6 +112,9 @@ public class FlashbackConfig {
     public float defaultOverrideFov = 70.0f;
     public boolean enableOverrideFovByDefault = false;
 
+    public float defaultOverrideGamma = 1.0f;
+    public boolean enableOverrideGammaByDefault = false;
+
     public ForceDefaultExportSettings forceDefaultExportSettings = new ForceDefaultExportSettings();
 
     public boolean filterUnnecessaryPackets = true;

--- a/src/main/java/com/moulberry/flashback/editor/ui/ReplayUI.java
+++ b/src/main/java/com/moulberry/flashback/editor/ui/ReplayUI.java
@@ -250,6 +250,7 @@ public class ReplayUI {
 
     private static short[] buildMaterialIconRanges() {
         ImFontGlyphRangesBuilder builder = new ImFontGlyphRangesBuilder();
+        builder.addChar('\ue0f0');
         builder.addChar('\ue04b');
         builder.addChar('\ue577');
         builder.addChar('\uefeb');

--- a/src/main/java/com/moulberry/flashback/editor/ui/windows/VisualsWindow.java
+++ b/src/main/java/com/moulberry/flashback/editor/ui/windows/VisualsWindow.java
@@ -5,6 +5,7 @@ import com.moulberry.flashback.keyframe.Keyframe;
 import com.moulberry.flashback.keyframe.KeyframeType;
 import com.moulberry.flashback.keyframe.impl.CameraShakeKeyframe;
 import com.moulberry.flashback.keyframe.impl.FOVKeyframe;
+import com.moulberry.flashback.keyframe.impl.GammaKeyframe;
 import com.moulberry.flashback.keyframe.impl.TimeOfDayKeyframe;
 import com.moulberry.flashback.playback.ReplayServer;
 import com.moulberry.flashback.record.FlashbackMeta;
@@ -171,6 +172,30 @@ public class VisualsWindow {
                 floatBuffer[0] = visuals.overrideFovAmount;
                 if (ImGui.sliderFloat("FOV", floatBuffer, 1.0f, 110.0f, "%.1f")) {
                     visuals.setFov(floatBuffer[0]);
+                    editorState.markDirty();
+                }
+            }
+
+            // Gamma
+            if (ImGui.checkbox("Override Gamma", visuals.overrideGamma)) {
+                visuals.overrideGamma = !visuals.overrideGamma;
+                Minecraft.getInstance().levelRenderer.needsUpdate();
+                editorState.markDirty();
+            }
+            if (visuals.overrideGamma) {
+                if (visuals.overrideGammaAmount < 0) {
+                    visuals.overrideGammaAmount = Flashback.getConfig().defaultOverrideGamma;
+                }
+
+                ImGui.sameLine();
+                if (ImGui.smallButton("+")) {
+                    addKeyframe(editorState, replayServer, new GammaKeyframe(visuals.overrideGammaAmount));
+                }
+                ImGuiHelper.tooltip("Add Gamma keyframe");
+
+                floatBuffer[0] = visuals.overrideGammaAmount;
+                if (ImGui.sliderFloat("Gamma", floatBuffer, 0.0f, 1.0f)) {
+                    visuals.setGamma(floatBuffer[0]);
                     editorState.markDirty();
                 }
             }

--- a/src/main/java/com/moulberry/flashback/ext/OptionsExt.java
+++ b/src/main/java/com/moulberry/flashback/ext/OptionsExt.java
@@ -4,4 +4,6 @@ public interface OptionsExt {
 
     int flashback$getOriginalFov();
 
+    double flashback$getOriginalGamma();
+
 }

--- a/src/main/java/com/moulberry/flashback/keyframe/Keyframe.java
+++ b/src/main/java/com/moulberry/flashback/keyframe/Keyframe.java
@@ -9,6 +9,7 @@ import com.moulberry.flashback.keyframe.impl.CameraShakeKeyframe;
 import com.moulberry.flashback.keyframe.impl.TrackEntityKeyframe;
 import com.moulberry.flashback.keyframe.impl.FOVKeyframe;
 import com.moulberry.flashback.keyframe.impl.FreezeKeyframe;
+import com.moulberry.flashback.keyframe.impl.GammaKeyframe;
 import com.moulberry.flashback.keyframe.impl.TickrateKeyframe;
 import com.moulberry.flashback.keyframe.impl.TimeOfDayKeyframe;
 import com.moulberry.flashback.keyframe.impl.TimelapseKeyframe;
@@ -55,6 +56,7 @@ public abstract class Keyframe {
                 case "camera_orbit" -> context.deserialize(json, CameraOrbitKeyframe.class);
                 case "track_entity" -> context.deserialize(json, TrackEntityKeyframe.class);
                 case "fov" -> context.deserialize(json, FOVKeyframe.class);
+                case "gamma" -> context.deserialize(json, GammaKeyframe.class);
                 case "tickrate" -> context.deserialize(json, TickrateKeyframe.class);
                 case "freeze" -> context.deserialize(json, FreezeKeyframe.class);
                 case "timelapse" -> context.deserialize(json, TimelapseKeyframe.class);
@@ -82,6 +84,10 @@ public abstract class Keyframe {
                 case FOVKeyframe fovKeyframe -> {
                     jsonObject = (JsonObject) context.serialize(fovKeyframe);
                     jsonObject.addProperty("type", "fov");
+                }
+                case GammaKeyframe gammaKeyframe -> {
+                    jsonObject = (JsonObject) context.serialize(gammaKeyframe);
+                    jsonObject.addProperty("type", "gamma");
                 }
                 case TickrateKeyframe tickrateKeyframe -> {
                     jsonObject = (JsonObject) context.serialize(tickrateKeyframe);

--- a/src/main/java/com/moulberry/flashback/keyframe/change/KeyframeChangeGamma.java
+++ b/src/main/java/com/moulberry/flashback/keyframe/change/KeyframeChangeGamma.java
@@ -1,0 +1,20 @@
+package com.moulberry.flashback.keyframe.change;
+
+import com.moulberry.flashback.Interpolation;
+import com.moulberry.flashback.Utils;
+import com.moulberry.flashback.keyframe.handler.KeyframeHandler;
+
+public record KeyframeChangeGamma(float gamma) implements KeyframeChange {
+    @Override
+    public void apply(KeyframeHandler keyframeHandler) {
+        keyframeHandler.applyGamma(this.gamma);
+    }
+
+    @Override
+    public KeyframeChange interpolate(KeyframeChange to, double amount) {
+        KeyframeChangeGamma other = (KeyframeChangeGamma) to;
+        float gamma = (float) Interpolation.linear(this.gamma, other.gamma, amount);
+        return new KeyframeChangeGamma(gamma);
+    }
+
+}

--- a/src/main/java/com/moulberry/flashback/keyframe/handler/KeyframeHandler.java
+++ b/src/main/java/com/moulberry/flashback/keyframe/handler/KeyframeHandler.java
@@ -27,6 +27,9 @@ public interface KeyframeHandler {
     default void applyFov(float fov) {
     }
 
+    default void applyGamma(float gamma) {
+    }
+
     default void applyTickrate(float tickrate) {
     }
 

--- a/src/main/java/com/moulberry/flashback/keyframe/handler/MinecraftKeyframeHandler.java
+++ b/src/main/java/com/moulberry/flashback/keyframe/handler/MinecraftKeyframeHandler.java
@@ -13,8 +13,13 @@ import java.util.Set;
 public record MinecraftKeyframeHandler(Minecraft minecraft) implements KeyframeHandler {
 
     private static final Set<Class<? extends KeyframeChange>> supportedChanges = Set.of(
-            KeyframeChangeCameraPosition.class, KeyframeChangeCameraPositionOrbit.class, KeyframeChangeTrackEntity.class,
-            KeyframeChangeFov.class, KeyframeChangeTimeOfDay.class, KeyframeChangeCameraShake.class
+        KeyframeChangeCameraPosition.class,
+        KeyframeChangeCameraPositionOrbit.class,
+        KeyframeChangeTrackEntity.class,
+        KeyframeChangeFov.class,
+        KeyframeChangeGamma.class,
+        KeyframeChangeTimeOfDay.class,
+        KeyframeChangeCameraShake.class
     );
 
     @Override
@@ -58,6 +63,14 @@ public record MinecraftKeyframeHandler(Minecraft minecraft) implements KeyframeH
         EditorState editorState = EditorStateManager.getCurrent();
         if (editorState != null) {
             editorState.replayVisuals.setFov(fov);
+        }
+    }
+
+    @Override
+    public void applyGamma(float gamma) {
+        EditorState editorState = EditorStateManager.getCurrent();
+        if (editorState != null) {
+            editorState.replayVisuals.setGamma(gamma);
         }
     }
 

--- a/src/main/java/com/moulberry/flashback/keyframe/handler/ReplayServerKeyframeHandler.java
+++ b/src/main/java/com/moulberry/flashback/keyframe/handler/ReplayServerKeyframeHandler.java
@@ -34,6 +34,11 @@ public record ReplayServerKeyframeHandler(ReplayServer replayServer) implements 
     }
 
     @Override
+    public void applyGamma(float gamma) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void applyTickrate(float tickrate) {
         this.replayServer.setDesiredTickRate(tickrate, false);
     }

--- a/src/main/java/com/moulberry/flashback/keyframe/impl/GammaKeyframe.java
+++ b/src/main/java/com/moulberry/flashback/keyframe/impl/GammaKeyframe.java
@@ -1,0 +1,113 @@
+package com.moulberry.flashback.keyframe.impl;
+
+import com.google.common.collect.Maps;
+import com.google.gson.*;
+import com.moulberry.flashback.Interpolation;
+import com.moulberry.flashback.Utils;
+import com.moulberry.flashback.keyframe.Keyframe;
+import com.moulberry.flashback.keyframe.KeyframeType;
+import com.moulberry.flashback.keyframe.change.KeyframeChange;
+import com.moulberry.flashback.keyframe.change.KeyframeChangeGamma;
+import com.moulberry.flashback.keyframe.handler.KeyframeHandler;
+import com.moulberry.flashback.keyframe.interpolation.InterpolationType;
+import com.moulberry.flashback.keyframe.types.GammaKeyframeType;
+import com.moulberry.flashback.spline.CatmullRom;
+import com.moulberry.flashback.spline.Hermite;
+import imgui.ImGui;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class GammaKeyframe extends Keyframe {
+
+    public float gamma;
+
+    public GammaKeyframe(float gamma) {
+        this(gamma, InterpolationType.getDefault());
+    }
+
+    public GammaKeyframe(float gamma, InterpolationType interpolationType) {
+        this.gamma = gamma;
+        this.interpolationType(interpolationType);
+    }
+
+    @Override
+    public KeyframeType<?> keyframeType() {
+        return GammaKeyframeType.INSTANCE;
+    }
+
+    @Override
+    public Keyframe copy() {
+        return new GammaKeyframe(this.gamma, this.interpolationType());
+    }
+
+    @Override
+    public void renderEditKeyframe(Consumer<Consumer<Keyframe>> update) {
+        ImGui.setNextItemWidth(160);
+        float[] input = new float[]{this.gamma};
+        if (ImGui.sliderFloat("Gamma", input, 0.0f, 1.0f)) {
+            if (this.gamma != input[0]) {
+                update.accept(keyframe -> ((GammaKeyframe) keyframe).gamma = input[0]);
+            }
+        }
+    }
+
+    @Override
+    public KeyframeChange createChange() {
+        return new KeyframeChangeGamma(this.gamma);
+    }
+
+    @Override
+    public KeyframeChange createSmoothInterpolatedChange(Keyframe p1, Keyframe p2, Keyframe p3,
+                                                         float t0, float t1, float t2, float t3,
+                                                         float amount) {
+        float time1 = t1 - t0;
+        float time2 = t2 - t0;
+        float time3 = t3 - t0;
+
+        float g0 = this.gamma;
+        float g1 = ((GammaKeyframe) p1).gamma;
+        float g2 = ((GammaKeyframe) p2).gamma;
+        float g3 = ((GammaKeyframe) p3).gamma;
+
+        float gamma = CatmullRom.value(g0, g1, g2, g3, time1, time2, time3, amount);
+
+        return new KeyframeChangeGamma(gamma);
+    }
+
+    @Override
+    public KeyframeChange createHermiteInterpolatedChange(Map<Float, Keyframe> keyframes,
+                                                          float amount) {
+        float gamma = (float) Hermite.value(
+                Maps.transformValues(keyframes, k -> (double) ((GammaKeyframe) k).gamma),
+                amount);
+        return new KeyframeChangeGamma(gamma);
+    }
+
+    public static class TypeAdapter implements JsonSerializer<GammaKeyframe>,
+                                               JsonDeserializer<GammaKeyframe> {
+        @Override
+        public GammaKeyframe deserialize(JsonElement json,
+                                         Type typeOfT,
+                                         JsonDeserializationContext context)
+                throws JsonParseException {
+            JsonObject jsonObject = json.getAsJsonObject();
+            float gamma = jsonObject.get("gamma").getAsFloat();
+            InterpolationType interpolationType =
+                context.deserialize(jsonObject.get("interpolation_type"), InterpolationType.class);
+            return new GammaKeyframe(gamma, interpolationType);
+        }
+
+        @Override
+        public JsonElement serialize(GammaKeyframe src, Type typeOfSrc,
+                                     JsonSerializationContext context) {
+            JsonObject jsonObject = new JsonObject();
+            jsonObject.addProperty("gamma", src.gamma);
+            jsonObject.addProperty("type", "gamma");
+            jsonObject.add("interpolation_type", context.serialize(src.interpolationType()));
+            return jsonObject;
+        }
+    }
+
+}

--- a/src/main/java/com/moulberry/flashback/keyframe/types/GammaKeyframeType.java
+++ b/src/main/java/com/moulberry/flashback/keyframe/types/GammaKeyframeType.java
@@ -1,0 +1,69 @@
+package com.moulberry.flashback.keyframe.types;
+
+import com.moulberry.flashback.keyframe.KeyframeType;
+import com.moulberry.flashback.keyframe.change.KeyframeChange;
+import com.moulberry.flashback.keyframe.change.KeyframeChangeGamma;
+import com.moulberry.flashback.keyframe.handler.KeyframeHandler;
+import com.moulberry.flashback.keyframe.impl.GammaKeyframe;
+import com.moulberry.flashback.state.EditorState;
+import com.moulberry.flashback.state.EditorStateManager;
+import imgui.ImGui;
+import imgui.type.ImFloat;
+import net.minecraft.client.Minecraft;
+import org.jetbrains.annotations.Nullable;
+
+
+public class GammaKeyframeType implements KeyframeType<GammaKeyframe> {
+
+    public static GammaKeyframeType INSTANCE = new GammaKeyframeType();
+
+    private GammaKeyframeType() {
+    }
+
+    @Override
+    public Class<? extends KeyframeChange> keyframeChangeType() {
+        return KeyframeChangeGamma.class;
+    }
+
+    @Override
+    public @Nullable String icon() {
+        return "\ue0f0";
+    }
+
+    @Override
+    public String name() {
+        return "Gamma";
+    }
+
+    @Override
+    public String id() {
+        return "Gamma";
+    }
+
+    @Override
+    public @Nullable GammaKeyframe createDirect() {
+        return null;
+    }
+
+    @Override
+    public KeyframeCreatePopup<GammaKeyframe> createPopup() {
+        float[] gammaKeyframeInput = new float[]{
+            Minecraft.getInstance().options.gamma().get().floatValue()};
+        EditorState editorState = EditorStateManager.getCurrent();
+        if (editorState != null && editorState.replayVisuals.overrideGamma) {
+            gammaKeyframeInput[0] = editorState.replayVisuals.overrideGammaAmount;
+        }
+
+        return () -> {
+            ImGui.sliderFloat("Gamma", gammaKeyframeInput, 0.0f, 1.0f);
+            if (ImGui.button("Add")) {
+                return new GammaKeyframe(gammaKeyframeInput[0]);
+            }
+            ImGui.sameLine();
+            if (ImGui.button("Cancel")) {
+                ImGui.closeCurrentPopup();
+            }
+            return null;
+        };
+    }
+}

--- a/src/main/java/com/moulberry/flashback/mixin/visuals/MixinOptions.java
+++ b/src/main/java/com/moulberry/flashback/mixin/visuals/MixinOptions.java
@@ -5,6 +5,7 @@ import com.moulberry.flashback.state.EditorStateManager;
 import com.moulberry.flashback.ext.OptionsExt;
 import net.minecraft.client.OptionInstance;
 import net.minecraft.client.Options;
+import net.minecraft.network.chat.Component;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -21,6 +22,12 @@ public class MixinOptions implements OptionsExt {
     private OptionInstance<Integer> fov;
     @Unique
     private OptionInstance<Integer> cachedFovOptionInstance = null;
+
+    @Shadow
+    @Final
+    private OptionInstance<Double> gamma;
+    @Unique
+    private OptionInstance<Double> cachedGammaOptionInstance = null;
 
     @Inject(method = "fov", at = @At("RETURN"), cancellable = true)
     public void fov(CallbackInfoReturnable<OptionInstance<Integer>> cir) {
@@ -42,5 +49,34 @@ public class MixinOptions implements OptionsExt {
     @Override
     public int flashback$getOriginalFov() {
         return this.fov.get();
+    }
+
+    @Inject(method = "gamma", at = @At("RETURN"), cancellable = true)
+    public void gamma(CallbackInfoReturnable<OptionInstance<Double>> cir) {
+        EditorState editorState = EditorStateManager.getCurrent();
+        if (editorState != null && editorState.replayVisuals.overrideGamma) {
+            if (this.cachedGammaOptionInstance == null || this.cachedGammaOptionInstance.get()
+                    != (double) editorState.replayVisuals.overrideGammaAmount) {
+                OptionInstance<Double> delegate = cir.getReturnValue();
+                this.cachedGammaOptionInstance = new OptionInstance<>(
+                        "options.gamma", OptionInstance.noTooltip(), (component, double_) -> {
+                            return Component.translatable("options.percent_value",
+                                                          component, (int) (double_ * 100.0));
+                        },
+                    delegate.values(), delegate.codec(),
+                    (double) editorState.replayVisuals.overrideGammaAmount,
+                    value -> {
+                        editorState.replayVisuals.overrideGamma = false;
+                        delegate.set((double) value);
+                    });
+            }
+
+            cir.setReturnValue(this.cachedGammaOptionInstance);
+        }
+    }
+
+    @Override
+    public double flashback$getOriginalGamma() {
+        return this.gamma.get();
     }
 }

--- a/src/main/java/com/moulberry/flashback/state/EditorState.java
+++ b/src/main/java/com/moulberry/flashback/state/EditorState.java
@@ -71,6 +71,12 @@ public class EditorState {
                 this.replayVisuals.overrideFovAmount = config.defaultOverrideFov;
             }
         }
+        if (config.enableOverrideGammaByDefault) {
+            this.replayVisuals.overrideGamma = true;
+            if (this.replayVisuals.overrideGammaAmount < 0) {
+                this.replayVisuals.overrideGammaAmount = config.defaultOverrideGamma;
+            }
+        }
     }
 
     @ApiStatus.Internal

--- a/src/main/java/com/moulberry/flashback/visuals/ReplayVisuals.java
+++ b/src/main/java/com/moulberry/flashback/visuals/ReplayVisuals.java
@@ -32,6 +32,9 @@ public class ReplayVisuals {
     public boolean overrideFov = false;
     public float overrideFovAmount = -1f;
 
+    public boolean overrideGamma = false;
+    public float overrideGammaAmount = -1f;
+
     public boolean overrideCameraShake = false;
     public boolean cameraShakeSplitParams = false;
     public float cameraShakeYFrequency = 1.0f;
@@ -61,6 +64,15 @@ public class ReplayVisuals {
 
         overrideFov = true;
         overrideFovAmount = fov;
+    }
+
+    public void setGamma(float gamma) {
+        if (!overrideGamma || Math.abs(overrideGammaAmount - gamma) >= 0.01) {
+            Minecraft.getInstance().levelRenderer.needsUpdate();
+        }
+
+        overrideGamma = true;
+        overrideGammaAmount = gamma;
     }
 
     public void setCameraShake(float frequencyX, float amplitudeX, float frequencyY, float amplitudeY) {


### PR DESCRIPTION
This PR allows overriding the gamma (Video Settings > Brightness) of a render, both from the right-hand pane and via a new keyframe type.

This allows for renders like the following:

https://github.com/user-attachments/assets/b5845c68-1fe4-48c9-89d0-c7d695548fda

Additionally, the Complementary Unbound shaders can use the gamma setting as a focal blur, so this change allow allows for renders like the following, when using that shaderpack:

https://github.com/user-attachments/assets/b80a503e-2b19-4e7c-af72-4ae2836d711b
