### PR TITLE
Fix FlashbackDrawBuffer's usage flag

### DIFF
--- a/src/main/java/com/moulberry/flashback/visuals/FlashbackDrawBuffer.java
+++ b/src/main/java/com/moulberry/flashback/visuals/FlashbackDrawBuffer.java
@@ -29,6 +29,9 @@ public class FlashbackDrawBuffer implements AutoCloseable {
 
     public FlashbackDrawBuffer(int usageFlags) {
         this.usageFlags = usageFlags;
+
+        // All draw buffers must have the USAGE_VERTEX flag set.
+        this.usageFlags |= GpuBuffer.USAGE_VERTEX;
     }
 
     @Override


### PR DESCRIPTION
Camera path rendering crashes when `SharedConstants.IS_RUNNING_IN_IDE` is set to true.
This happens because, `GlCommandEncoder#executeDraw` expects the vertex buffer to have the `GpuBuffer.USAGE_VERTEX` flag set.
