### PR TITLE
feat: support overriding skins of mannequins

### DIFF
--- a/src/main/java/com/moulberry/flashback/editor/ui/windows/SelectedEntityPopup.java
+++ b/src/main/java/com/moulberry/flashback/editor/ui/windows/SelectedEntityPopup.java
@@ -174,7 +174,9 @@ public class SelectedEntityPopup {
                 }
 
                 showGlowingDropdown(entity, editorState);
+            }
 
+            if (entity instanceof AbstractClientPlayer || entity instanceof ClientMannequin) {
                 ImGuiHelper.separatorWithText(I18n.get("flashback.change_skin_and_cape"));
                 ImGui.setNextItemWidth(320);
                 ImGui.inputTextWithHint("##SetSkinInput", "e.g. d0e05de7-6067-454d-beae-c6d19d886191", changeSkinInput);

--- a/src/main/java/com/moulberry/flashback/mixin/visuals/MixinClientMannequin.java
+++ b/src/main/java/com/moulberry/flashback/mixin/visuals/MixinClientMannequin.java
@@ -1,0 +1,51 @@
+package com.moulberry.flashback.mixin.visuals;
+
+import com.mojang.authlib.GameProfile;
+import com.moulberry.flashback.FilePlayerSkin;
+import com.moulberry.flashback.state.EditorState;
+import com.moulberry.flashback.state.EditorStateManager;
+import net.minecraft.client.entity.ClientMannequin;
+import net.minecraft.client.multiplayer.PlayerInfo;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.decoration.Mannequin;
+import net.minecraft.world.entity.player.PlayerSkin;
+import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ClientMannequin.class)
+public abstract class MixinClientMannequin extends LivingEntity {
+
+    @Unique
+    private PlayerInfo skinOverridePlayerInfo = null;
+
+    public MixinClientMannequin(EntityType<Mannequin> entityType, Level level) {
+        super(entityType, level);
+    }
+
+    @Inject(method = "getSkin", at = @At("HEAD"), cancellable = true, require = 0)
+    public void getSkin(CallbackInfoReturnable<PlayerSkin> cir) {
+        EditorState editorState = EditorStateManager.getCurrent();
+        if (editorState != null) {
+            FilePlayerSkin filePlayerSkin = editorState.skinOverrideFromFile.get(this.getUUID());
+            if (filePlayerSkin != null) {
+                cir.setReturnValue(filePlayerSkin.getSkin());
+                return;
+            }
+
+            GameProfile skinOverride = editorState.skinOverride.get(this.getUUID());
+            if (skinOverride != null) {
+                if (skinOverridePlayerInfo == null || skinOverridePlayerInfo.getProfile() != skinOverride) {
+                    skinOverridePlayerInfo = new PlayerInfo(skinOverride, false);
+                }
+                cir.setReturnValue(skinOverridePlayerInfo.getSkin());
+            }
+        }
+    }
+}

--- a/src/main/resources/flashback.mixins.json
+++ b/src/main/resources/flashback.mixins.json
@@ -41,6 +41,7 @@
     "visuals.MixinBossHealthOverlay",
     "visuals.MixinClientLevel",
     "visuals.MixinClientLevelData",
+    "visuals.MixinClientMannequin",
     "visuals.MixinEntityRenderDispatcher",
     "visuals.MixinEntityRenderer",
     "visuals.MixinExperienceBarRenderer",


### PR DESCRIPTION
In 1.21.9 a new mob called [Mannequin](https://minecraft.wiki/w/Mannequin) was added to Minecraft.
It looks like a player, but it is a NPC, thus it is very handy when recording videos.

For that reason, I just copied your part of `MixinAbstractClientPlayer` and modified one `if` statement in `SelectedEntityPopup.java`, so it should be fine to merge as is. Alternatively, it might be even better for you to recreate it yourself without duplicating code in the `MixinClientMannequin.java`