### PR TITLE
Fix self-deadlock when Ctrl-scrubbing the timeline

### DIFF
--- a/src/main/java/com/moulberry/flashback/editor/ui/windows/TimelineWindow.java
+++ b/src/main/java/com/moulberry/flashback/editor/ui/windows/TimelineWindow.java
@@ -292,7 +292,13 @@ public class TimelineWindow {
                 }
             }
             if (isCtrlDown) {
+                // applyKeyframes may need to acquire a write lock internally; sceneLock is non-reentrant,
+                // so release our outer read first and re-acquire afterwards
+                editorState.release(editorSceneStamp);
                 editorState.applyKeyframes(new MinecraftKeyframeHandler(Minecraft.getInstance()), cursorTicks);
+                editorSceneStamp = editorState.acquireRead();
+                editorSceneStampIsWrite = false;
+                editorScene = editorState.getCurrentScene(editorSceneStamp);
             }
             if (!isCtrlDown && !isShiftDown) {
                 ImGuiHelper.drawTooltip(I18n.get("flashback.hold_ctrl_to_apply_keyframes"));


### PR DESCRIPTION
## Summary

While holding Ctrl and scrubbing the timeline, the client (and the integrated replay server) deadlock on `EditorState.sceneLock`, leaving the game in a permanent "Not Responding" state. Confirmed via `jstack` on the hung JVM — both the Render thread and the server thread are parked on `acquireWrite` of the same StampedLock.

## Root cause

`TimelineWindow.render` acquires a **read** lock on `EditorState.sceneLock` at line 173 and holds it for the entire frame. The Ctrl-hold branch then calls `EditorState.applyKeyframes`, which internally invokes `updateRealtimeMappingsIfNeeded`. That method takes the read → releases it → calls `sceneLock.writeLock()`.

`sceneLock` is a non-reentrant `StampedLock`, so the `writeLock()` call has to wait for *all* outstanding readers — including the render thread's own outer read lock from line 173. The thread parks waiting on itself. `ReplayServer.runUpdates` then queues a second `writeLock()` waiter, making the stall permanent. Without Ctrl-hold the deadlock path is never entered, because `applyKeyframes` isn't called from inside the outer read.

Thread dump excerpt:

```
"Render thread" ... waiting on condition
    at java.util.concurrent.locks.StampedLock.acquireWrite(...)
    at com.moulberry.flashback.state.EditorState.updateRealtimeMappingsIfNeeded(EditorState.java:280)
    at com.moulberry.flashback.state.EditorState.applyKeyframes(EditorState.java:202)
    at com.moulberry.flashback.editor.ui.windows.TimelineWindow.renderInner(TimelineWindow.java:299)

"Server thread" ... waiting on condition
    at java.util.concurrent.locks.StampedLock.acquireWrite(...)
    at com.moulberry.flashback.state.EditorState.updateRealtimeMappingsIfNeeded(EditorState.java:280)
    at com.moulberry.flashback.state.EditorState.applyKeyframes(EditorState.java:202)
    at com.moulberry.flashback.playback.ReplayServer.runUpdates(ReplayServer.java:1089)
```

## Fix

Release the outer read lock immediately before calling `applyKeyframes` and re-acquire it after, matching the existing `upgradeToSceneWrite()` release/re-acquire pattern in the same file. `editorScene` is re-read against the new stamp so subsequent code in the same frame still sees a valid snapshot.

## Test plan

- [x] Repro before patch: hold Ctrl while dragging the playhead → JVM hangs within seconds, thread dump shows the self-deadlock above.
- [x] Apply patch, rebuild, drop into mods folder.
- [x] Repeat Ctrl-hold scrub — no hang, keyframes apply as expected.