### PR TITLE
fix imgui.ini path so layout persists across launchers

### DIFF
--- a/src/main/java/com/moulberry/flashback/editor/ui/ReplayUI.java
+++ b/src/main/java/com/moulberry/flashback/editor/ui/ReplayUI.java
@@ -152,8 +152,7 @@ public class ReplayUI {
 
         imGuiIO = new ImGuiIO(ImGui.getIO().ptr);
 
-        Path relativePath = FabricLoader.getInstance().getGameDir().relativize(path);
-        imGuiIO.setIniFilename(relativePath.toString());
+        imGuiIO.setIniFilename(path.toAbsolutePath().toString());
 
         imGuiIO.addConfigFlags(ImGuiConfigFlags.DockingEnable);
         imGuiIO.setConfigMacOSXBehaviors(InputQuirks.REPLACE_CTRL_KEY_WITH_CMD_KEY);


### PR DESCRIPTION
The Flashback UI layout was resetting every time Lunar Client launched. Lunar is not officially supported, but this bug can affect any launcher where the process working directory is different from the Minecraft game/instance directory.

This happened because the imgui.ini path was being passed as a relative path. On Prism, the working directory lines up with the Minecraft instance folder, so the ini file persists correctly. On Lunar and some other launchers, the working directory can be somewhere else, so imgui could not find the saved ini file and kept falling back to the default layout.

Changed it so Flashback passes the absolute path to config/flashback/imgui.ini instead.

Tested on:
- Lunar Client: layout now saves between launches
- Prism instance: still works the same as before