### PR TITLE
Fix Shift + mouse wheel horizontal scrolling on macOS

### DIFF
--- a/src/main/java/com/moulberry/flashback/editor/ui/CustomImGuiImplGlfw.java
+++ b/src/main/java/com/moulberry/flashback/editor/ui/CustomImGuiImplGlfw.java
@@ -517,7 +517,7 @@ public class CustomImGuiImplGlfw {
         }
 
         if (this.prevUserCallbackScroll != null && windowId == this.mainWindowPtr) {
-            this.prevUserCallbackScroll.invoke(windowId, 0, yOffset);
+            this.prevUserCallbackScroll.invoke(windowId, xOffset, yOffset);
         }
     }
 


### PR DESCRIPTION
This fixes horizontal scrolling behavior on macOS when Shift is pressed.

Currently, the Flashback mod intercepts scroll events and removes the `xOffset`, replacing it with `0`. As a result, hotbar scrolling is blocked on macOS when Shift is pressed, because macOS interprets Shift + vertical mouse wheel scrolling as horizontal scrolling.

I tested this fix locally on my machine, and my usual workflow of recording, editing, and exporting videos remains unchanged. However, I cannot verify the same behavior on Windows or Linux.

I would appreciate it if someone could check whether this fix affects anything else on macOS or other platforms. I usually patch Flashback locally to fix this issue in my personal modpack, so I hope this fix will help others as well.
