### PR TITLE
Fix disconnect when recording during a server switch

### DIFF
--- a/src/main/java/com/moulberry/flashback/record/Recorder.java
+++ b/src/main/java/com/moulberry/flashback/record/Recorder.java
@@ -895,7 +895,14 @@ public class Recorder {
 
         LocalPlayer localPlayer = Minecraft.getInstance().player;
         if (localPlayer != null) {
-            int localPlayerId = localPlayer.getId();
+            int localPlayerId;
+            try {
+                localPlayerId = localPlayer.getId();
+            } catch (IllegalStateException e) {
+                // Player exists but has no entity id yet. Happens on proxied servers while the
+                // client is being moved between backends.
+                localPlayerId = -1;
+            }
             if (packet instanceof ClientboundSetEntityDataPacket entityDataPacket && entityDataPacket.id() == localPlayerId) {
                 return;
             }


### PR DESCRIPTION
We run a Minecraft network (LoverFella) behind Velocity. Staff who record with Flashback get disconnected when the proxy moves them between backend servers. Two reports so far, both with the same stack:

```
java.lang.IllegalStateException: Tried to access entity ID before ID assignment
	at net.minecraft.world.entity.Entity.getId(Entity.java:438)
	at com.moulberry.flashback.record.Recorder.writePacketAsync(Recorder.java:898)
	at net.minecraft.network.Connection.handler$bgb000$flashback$genericsFtw(Connection.java:1749)
	at net.minecraft.network.Connection.channelRead0(Connection.java:167)
```

Flashback 0.42.1, Minecraft 26.2, Fabric.

`writePacketAsync` null-checks the local player before calling `getId()`, but `getId()` throws when the entity has not been assigned an id yet, so non-null is not enough. On a proxy the client has already built the LocalPlayer for the server it is being sent to while packets for it are still arriving, which lands inside that window. The exception goes up through `channelRead0` and the client drops the connection with a packet handling error.

Both of our reports happened inside our scheduled restart window, which is exactly when players get moved between backends.

The patch catches the exception and falls back to -1. No real entity id matches that, so the two filters below simply do not match and the packet is recorded like any other. Recording two packets that would otherwise be skipped seemed better than losing the connection.
