### PR TITLE
Backport 1d1666b: fix NPE when player info update arrives for unknown player

### DIFF
--- a/src/main/java/com/moulberry/flashback/playback/ReplayGamePacketHandler.java
+++ b/src/main/java/com/moulberry/flashback/playback/ReplayGamePacketHandler.java
@@ -948,6 +948,9 @@ public class ReplayGamePacketHandler implements ClientGamePacketListener {
         }
         for (ClientboundPlayerInfoUpdatePacket.Entry entry : clientboundPlayerInfoUpdatePacket.entries()) {
             var playerInfo = this.playerInfoMap.get(entry.profileId());
+            if (playerInfo == null) {
+                continue;
+            }
             for (ClientboundPlayerInfoUpdatePacket.Action action : clientboundPlayerInfoUpdatePacket.actions()) {
                 this.applyPlayerInfoUpdate(action, entry, playerInfo);
             }


### PR DESCRIPTION
Backports 1d1666b ("Fix crash when server sends info update for player that doesnt exist")
from `master` to the `1.21.11` branch.

`handlePlayerInfoUpdate` passes the result of `playerInfoMap.get(entry.profileId())` straight into
`applyPlayerInfoUpdate` without a null check. If the replay stream contains an update action for a
profile id that is not (or is no longer) in the map — the player was removed via
`ClientboundPlayerInfoRemovePacket`, or `ADD_PLAYER` never arrived for that UUID (vanished players,
proxy/anticheat plugins, fake tab-list entries) — every non-empty branch of the switch throws.

Because this runs on the server thread inside `ReplayServer.runUpdates`, it takes down the whole
replay session instead of skipping one bad entry.

Reproduced on Minecraft 1.21.11 / Fabric with Flashback 0.39.7 during playback of a 6-player
recording. Line 975 in that build is `playerInfo.setShowHat(entry.showHat())`, i.e. the `UPDATE_HAT`
action:

```
java.lang.NullPointerException: Cannot invoke "net.minecraft.class_640.method_65194(boolean)" because "playerInfo" is null
    at com.moulberry.flashback.playback.ReplayGamePacketHandler.applyPlayerInfoUpdate(ReplayGamePacketHandler.java:975)
    at com.moulberry.flashback.playback.ReplayGamePacketHandler.method_11113(ReplayGamePacketHandler.java:952)
    at net.minecraft.class_2703.method_11721(class_2703.java:76)
    at net.minecraft.class_2703.method_65081(class_2703.java:27)
    at com.moulberry.flashback.playback.ReplayServer.handleGamePacket(ReplayServer.java:671)
    at com.moulberry.flashback.action.ActionGamePacket.handle(ActionGamePacket.java:22)
    at com.moulberry.flashback.io.ReplayReader.handleNextAction(ReplayReader.java:130)
    at com.moulberry.flashback.playback.ReplayServer.handleActions(ReplayServer.java:1376)
    at com.moulberry.flashback.playback.ReplayServer.runUpdates(ReplayServer.java:1136)
    at com.moulberry.flashback.playback.ReplayServer.method_3748(ReplayServer.java:926)
```

The change is identical to the one already on `master`.
