### PR TITLE
Fix replay recipe sync registry mismatch

### DIFF
--- a/src/main/java/com/moulberry/flashback/mixin/playback/MixinMinecraftServer.java
+++ b/src/main/java/com/moulberry/flashback/mixin/playback/MixinMinecraftServer.java
@@ -22,8 +22,8 @@ public class MixinMinecraftServer {
 
     @WrapOperation(method = "method_29437", at = @At(value = "INVOKE", target = "Lnet/minecraft/tags/TagLoader;loadTagsForExistingRegistries(Lnet/minecraft/server/packs/resources/ResourceManager;Lnet/minecraft/core/RegistryAccess;)Ljava/util/List;"))
     public List<Registry.PendingTags<?>> loadTagsForExistingRegistries(ResourceManager resourceManager, RegistryAccess registryAccess, Operation<List<Registry.PendingTags<?>>> original) {
-        if ((Object) this instanceof ReplayServer replayServer && replayServer.overridePendingTags != null) {
-            return replayServer.overridePendingTags;
+        if ((Object) this instanceof ReplayServer) {
+            return List.of();
         }
         return original.call(resourceManager, registryAccess);
     }

--- a/src/main/java/com/moulberry/flashback/mixin/playback/MixinMinecraftServer.java
+++ b/src/main/java/com/moulberry/flashback/mixin/playback/MixinMinecraftServer.java
@@ -15,13 +15,15 @@ import java.util.List;
 @Mixin(MinecraftServer.class)
 public class MixinMinecraftServer {
 
-    /* Keep the tags already installed on replay registries instead of replacing
-     * them with tags from the replay server's empty datapack repository. */
+    /*
+     * Keep the tags already installed on replay registries instead of trying
+     * to load them from the replay server's empty datapack repository.
+     */
 
     @WrapOperation(method = "method_29437", at = @At(value = "INVOKE", target = "Lnet/minecraft/tags/TagLoader;loadTagsForExistingRegistries(Lnet/minecraft/server/packs/resources/ResourceManager;Lnet/minecraft/core/RegistryAccess;)Ljava/util/List;"))
     public List<Registry.PendingTags<?>> loadTagsForExistingRegistries(ResourceManager resourceManager, RegistryAccess registryAccess, Operation<List<Registry.PendingTags<?>>> original) {
-        if ((Object) this instanceof ReplayServer) {
-            return List.of();
+        if ((Object) this instanceof ReplayServer replayServer && replayServer.overridePendingTags != null) {
+            return replayServer.overridePendingTags;
         }
         return original.call(resourceManager, registryAccess);
     }

--- a/src/main/java/com/moulberry/flashback/mixin/playback/MixinMinecraftServer.java
+++ b/src/main/java/com/moulberry/flashback/mixin/playback/MixinMinecraftServer.java
@@ -15,15 +15,13 @@ import java.util.List;
 @Mixin(MinecraftServer.class)
 public class MixinMinecraftServer {
 
-    /*
-     * Force the server to use the pending tags we gathered instead of trying
-     * to load them from the resource pack repository where it doesn't exist
-     */
+    /* Keep the tags already installed on replay registries instead of replacing
+     * them with tags from the replay server's empty datapack repository. */
 
     @WrapOperation(method = "method_29437", at = @At(value = "INVOKE", target = "Lnet/minecraft/tags/TagLoader;loadTagsForExistingRegistries(Lnet/minecraft/server/packs/resources/ResourceManager;Lnet/minecraft/core/RegistryAccess;)Ljava/util/List;"))
     public List<Registry.PendingTags<?>> loadTagsForExistingRegistries(ResourceManager resourceManager, RegistryAccess registryAccess, Operation<List<Registry.PendingTags<?>>> original) {
-        if ((Object) this instanceof ReplayServer replayServer && replayServer.overridePendingTags != null) {
-            return replayServer.overridePendingTags;
+        if ((Object) this instanceof ReplayServer) {
+            return List.of();
         }
         return original.call(resourceManager, registryAccess);
     }

--- a/src/main/java/com/moulberry/flashback/playback/ReplayConfigurationPacketHandler.java
+++ b/src/main/java/com/moulberry/flashback/playback/ReplayConfigurationPacketHandler.java
@@ -79,9 +79,8 @@ public class ReplayConfigurationPacketHandler implements ClientConfigurationPack
             this.pendingResetChat = false;
         }
 
-        List<Registry.PendingTags<?>> pendingTags = new ArrayList<>();
-
         if (this.pendingTags != null && !this.pendingTags.isEmpty()) {
+            List<Registry.PendingTags<?>> pendingTags = new ArrayList<>();
             this.pendingTags.forEach((resourceKey, networkPayload) -> {
                 var registry = this.replayServer.registryAccess().lookupOrThrow(resourceKey);
                 var loadResult = networkPayload.resolve(registry);
@@ -94,8 +93,6 @@ public class ReplayConfigurationPacketHandler implements ClientConfigurationPack
                 pendingTags.add(registry.prepareTagReload(loadResult));
             });
             pendingTags.forEach(Registry.PendingTags::apply);
-            // PendingTags retain the local registry's holders, so do not reuse them after the recorded registry may replace it.
-            pendingTags.clear();
             sendTags = true;
             this.pendingTags = null;
         }
@@ -105,10 +102,10 @@ public class ReplayConfigurationPacketHandler implements ClientConfigurationPack
         if (this.pendingRegistryMap != null && !this.pendingRegistryMap.isEmpty()) {
             if (this.packRepository != null) {
                 try (CloseableResourceManager resourceManager = new MultiPackResourceManager(PackType.SERVER_DATA, this.packRepository.openAllSelected())) {
-                    synchronizeRegistries = tryUpdateRegistries(pendingTags, resourceManager);
+                    synchronizeRegistries = tryUpdateRegistries(resourceManager);
                 }
             } else {
-                synchronizeRegistries = tryUpdateRegistries(pendingTags, ResourceProvider.EMPTY);
+                synchronizeRegistries = tryUpdateRegistries(ResourceProvider.EMPTY);
             }
         }
 
@@ -122,7 +119,7 @@ public class ReplayConfigurationPacketHandler implements ClientConfigurationPack
             return;
         }
 
-        this.replayServer.updateRegistry(currentFeatureFlags, pendingTags, initialPackets, configurationTasks, this.knownPackIds);
+        this.replayServer.updateRegistry(currentFeatureFlags, initialPackets, configurationTasks, this.knownPackIds);
 
         // Remove all players
         for (ServerPlayer player : new ArrayList<>(this.replayServer.getPlayerList().getPlayers())) {
@@ -139,11 +136,11 @@ public class ReplayConfigurationPacketHandler implements ClientConfigurationPack
         this.replayServer.loadLevel();
     }
 
-    private boolean tryUpdateRegistries(List<Registry.PendingTags<?>> pendingTags, ResourceProvider resourceProvider) {
+    private boolean tryUpdateRegistries(ResourceProvider resourceProvider) {
         Map<ResourceKey<? extends Registry<?>>, RegistryDataLoader.NetworkedRegistryData> entries = this.pendingRegistryMap;
         this.pendingRegistryMap = null;
 
-        List<HolderLookup.RegistryLookup<?>> updatedLookups = TagLoader.buildUpdatedLookups(this.replayServer.registryAccess(), pendingTags);
+        List<HolderLookup.RegistryLookup<?>> updatedLookups = TagLoader.buildUpdatedLookups(this.replayServer.registryAccess(), List.of());
 
         RegistryAccess.Frozen synchronizedRegistries;
         try {

--- a/src/main/java/com/moulberry/flashback/playback/ReplayConfigurationPacketHandler.java
+++ b/src/main/java/com/moulberry/flashback/playback/ReplayConfigurationPacketHandler.java
@@ -79,23 +79,23 @@ public class ReplayConfigurationPacketHandler implements ClientConfigurationPack
             this.pendingResetChat = false;
         }
 
+        List<Registry.PendingTags<?>> pendingTags = new ArrayList<>();
+
         if (this.pendingTags != null && !this.pendingTags.isEmpty()) {
             this.pendingTags.forEach((resourceKey, networkPayload) -> {
+                var registry = this.replayServer.registryAccess().lookupOrThrow(resourceKey);
+                var loadResult = networkPayload.resolve(registry);
                 if (this.pendingRegistryMap != null) {
                     var entry = this.pendingRegistryMap.get(resourceKey);
                     if (entry != null) {
                         this.pendingRegistryMap.put(resourceKey, new RegistryDataLoader.NetworkedRegistryData(entry.elements(), networkPayload));
                     }
                 }
-
-                // Apply the tags in case the local registry remains active. If the recorded
-                // registry replaces it, RegistryDataLoader applies the same payload there and
-                // this local tag state is discarded.
-                var localRegistry = this.replayServer.registryAccess().lookupOrThrow(resourceKey);
-                var loadResult = networkPayload.resolve(localRegistry);
-                var pending = localRegistry.prepareTagReload(loadResult);
-                pending.apply();
+                pendingTags.add(registry.prepareTagReload(loadResult));
             });
+            pendingTags.forEach(Registry.PendingTags::apply);
+            // PendingTags retain the local registry's holders, so do not reuse them after the recorded registry may replace it.
+            pendingTags.clear();
             sendTags = true;
             this.pendingTags = null;
         }
@@ -105,10 +105,10 @@ public class ReplayConfigurationPacketHandler implements ClientConfigurationPack
         if (this.pendingRegistryMap != null && !this.pendingRegistryMap.isEmpty()) {
             if (this.packRepository != null) {
                 try (CloseableResourceManager resourceManager = new MultiPackResourceManager(PackType.SERVER_DATA, this.packRepository.openAllSelected())) {
-                    synchronizeRegistries = tryUpdateRegistries(resourceManager);
+                    synchronizeRegistries = tryUpdateRegistries(pendingTags, resourceManager);
                 }
             } else {
-                synchronizeRegistries = tryUpdateRegistries(ResourceProvider.EMPTY);
+                synchronizeRegistries = tryUpdateRegistries(pendingTags, ResourceProvider.EMPTY);
             }
         }
 
@@ -122,7 +122,7 @@ public class ReplayConfigurationPacketHandler implements ClientConfigurationPack
             return;
         }
 
-        this.replayServer.updateRegistry(currentFeatureFlags, initialPackets, configurationTasks, this.knownPackIds);
+        this.replayServer.updateRegistry(currentFeatureFlags, pendingTags, initialPackets, configurationTasks, this.knownPackIds);
 
         // Remove all players
         for (ServerPlayer player : new ArrayList<>(this.replayServer.getPlayerList().getPlayers())) {
@@ -139,11 +139,11 @@ public class ReplayConfigurationPacketHandler implements ClientConfigurationPack
         this.replayServer.loadLevel();
     }
 
-    private boolean tryUpdateRegistries(ResourceProvider resourceProvider) {
+    private boolean tryUpdateRegistries(List<Registry.PendingTags<?>> pendingTags, ResourceProvider resourceProvider) {
         Map<ResourceKey<? extends Registry<?>>, RegistryDataLoader.NetworkedRegistryData> entries = this.pendingRegistryMap;
         this.pendingRegistryMap = null;
 
-        List<HolderLookup.RegistryLookup<?>> updatedLookups = TagLoader.buildUpdatedLookups(this.replayServer.registryAccess(), List.of());
+        List<HolderLookup.RegistryLookup<?>> updatedLookups = TagLoader.buildUpdatedLookups(this.replayServer.registryAccess(), pendingTags);
 
         RegistryAccess.Frozen synchronizedRegistries;
         try {

--- a/src/main/java/com/moulberry/flashback/playback/ReplayConfigurationPacketHandler.java
+++ b/src/main/java/com/moulberry/flashback/playback/ReplayConfigurationPacketHandler.java
@@ -79,23 +79,22 @@ public class ReplayConfigurationPacketHandler implements ClientConfigurationPack
             this.pendingResetChat = false;
         }
 
-        Map<ResourceKey<? extends Registry<?>>, TagNetworkSerialization.NetworkPayload> synchronizedRegistryTags = new HashMap<>();
-
         if (this.pendingTags != null && !this.pendingTags.isEmpty()) {
             this.pendingTags.forEach((resourceKey, networkPayload) -> {
-                var registry = this.replayServer.registryAccess().lookupOrThrow(resourceKey);
                 if (this.pendingRegistryMap != null) {
                     var entry = this.pendingRegistryMap.get(resourceKey);
                     if (entry != null) {
-                        // The payload's element ids belong to the recorded registry. Load it with
-                        // that registry, and only resolve it against the local registry if the
-                        // recorded registry is discarded below.
                         this.pendingRegistryMap.put(resourceKey, new RegistryDataLoader.NetworkedRegistryData(entry.elements(), networkPayload));
-                        synchronizedRegistryTags.put(resourceKey, networkPayload);
-                        return;
                     }
                 }
-                applyTags(registry, networkPayload);
+
+                // Apply the tags in case the local registry remains active. If the recorded
+                // registry replaces it, RegistryDataLoader applies the same payload there and
+                // this local tag state is discarded.
+                var localRegistry = this.replayServer.registryAccess().lookupOrThrow(resourceKey);
+                var loadResult = networkPayload.resolve(localRegistry);
+                var pending = localRegistry.prepareTagReload(loadResult);
+                pending.apply();
             });
             sendTags = true;
             this.pendingTags = null;
@@ -111,15 +110,6 @@ public class ReplayConfigurationPacketHandler implements ClientConfigurationPack
             } else {
                 synchronizeRegistries = tryUpdateRegistries(ResourceProvider.EMPTY);
             }
-        }
-
-        if (!synchronizeRegistries) {
-            // A registry is not replaced when its elements are unchanged, even if its tags differ.
-            // Apply those recorded tags to the registry that remains active so they are not lost.
-            synchronizedRegistryTags.forEach((resourceKey, networkPayload) -> {
-                var registry = this.replayServer.registryAccess().lookupOrThrow(resourceKey);
-                applyTags(registry, networkPayload);
-            });
         }
 
         if (synchronizeRegistries) {
@@ -147,12 +137,6 @@ public class ReplayConfigurationPacketHandler implements ClientConfigurationPack
 
         // Recreate levels
         this.replayServer.loadLevel();
-    }
-
-    private static <T> void applyTags(Registry<T> registry, TagNetworkSerialization.NetworkPayload networkPayload) {
-        var loadResult = networkPayload.resolve(registry);
-        var pending = registry.prepareTagReload(loadResult);
-        pending.apply();
     }
 
     private boolean tryUpdateRegistries(ResourceProvider resourceProvider) {

--- a/src/main/java/com/moulberry/flashback/playback/ReplayConfigurationPacketHandler.java
+++ b/src/main/java/com/moulberry/flashback/playback/ReplayConfigurationPacketHandler.java
@@ -96,10 +96,8 @@ public class ReplayConfigurationPacketHandler implements ClientConfigurationPack
                         return;
                     }
                 }
-                var loadResult = networkPayload.resolve(registry);
-                pendingTags.add(registry.prepareTagReload(loadResult));
+                addAndApplyPendingTags(pendingTags, registry, networkPayload);
             });
-            pendingTags.forEach(Registry.PendingTags::apply);
             sendTags = true;
             this.pendingTags = null;
         }
@@ -121,10 +119,7 @@ public class ReplayConfigurationPacketHandler implements ClientConfigurationPack
             // Apply those recorded tags to the registry that remains active so they are not lost.
             synchronizedRegistryTags.forEach((resourceKey, networkPayload) -> {
                 var registry = this.replayServer.registryAccess().lookupOrThrow(resourceKey);
-                var loadResult = networkPayload.resolve(registry);
-                var pending = registry.prepareTagReload(loadResult);
-                pending.apply();
-                pendingTags.add(pending);
+                addAndApplyPendingTags(pendingTags, registry, networkPayload);
             });
         }
 
@@ -153,6 +148,14 @@ public class ReplayConfigurationPacketHandler implements ClientConfigurationPack
 
         // Recreate levels
         this.replayServer.loadLevel();
+    }
+
+    private static <T> void addAndApplyPendingTags(List<Registry.PendingTags<?>> pendingTags, Registry<T> registry,
+                                                   TagNetworkSerialization.NetworkPayload networkPayload) {
+        var loadResult = networkPayload.resolve(registry);
+        var pending = registry.prepareTagReload(loadResult);
+        pending.apply();
+        pendingTags.add(pending);
     }
 
     private boolean tryUpdateRegistries(List<Registry.PendingTags<?>> pendingTags, ResourceProvider resourceProvider) {

--- a/src/main/java/com/moulberry/flashback/playback/ReplayConfigurationPacketHandler.java
+++ b/src/main/java/com/moulberry/flashback/playback/ReplayConfigurationPacketHandler.java
@@ -80,7 +80,6 @@ public class ReplayConfigurationPacketHandler implements ClientConfigurationPack
         }
 
         if (this.pendingTags != null && !this.pendingTags.isEmpty()) {
-            List<Registry.PendingTags<?>> pendingTags = new ArrayList<>();
             this.pendingTags.forEach((resourceKey, networkPayload) -> {
                 var registry = this.replayServer.registryAccess().lookupOrThrow(resourceKey);
                 var loadResult = networkPayload.resolve(registry);
@@ -90,9 +89,8 @@ public class ReplayConfigurationPacketHandler implements ClientConfigurationPack
                         this.pendingRegistryMap.put(resourceKey, new RegistryDataLoader.NetworkedRegistryData(entry.elements(), networkPayload));
                     }
                 }
-                pendingTags.add(registry.prepareTagReload(loadResult));
+                registry.prepareTagReload(loadResult).apply();
             });
-            pendingTags.forEach(Registry.PendingTags::apply);
             sendTags = true;
             this.pendingTags = null;
         }

--- a/src/main/java/com/moulberry/flashback/playback/ReplayConfigurationPacketHandler.java
+++ b/src/main/java/com/moulberry/flashback/playback/ReplayConfigurationPacketHandler.java
@@ -79,7 +79,6 @@ public class ReplayConfigurationPacketHandler implements ClientConfigurationPack
             this.pendingResetChat = false;
         }
 
-        List<Registry.PendingTags<?>> pendingTags = new ArrayList<>();
         Map<ResourceKey<? extends Registry<?>>, TagNetworkSerialization.NetworkPayload> synchronizedRegistryTags = new HashMap<>();
 
         if (this.pendingTags != null && !this.pendingTags.isEmpty()) {
@@ -88,15 +87,15 @@ public class ReplayConfigurationPacketHandler implements ClientConfigurationPack
                 if (this.pendingRegistryMap != null) {
                     var entry = this.pendingRegistryMap.get(resourceKey);
                     if (entry != null) {
-                        // Resolving these tags against the current registry would make resource
-                        // reloads retain its holders. Registry-aware codecs cannot encode those
-                        // holders against the recorded registry, disconnecting replay playback.
+                        // The payload's element ids belong to the recorded registry. Load it with
+                        // that registry, and only resolve it against the local registry if the
+                        // recorded registry is discarded below.
                         this.pendingRegistryMap.put(resourceKey, new RegistryDataLoader.NetworkedRegistryData(entry.elements(), networkPayload));
                         synchronizedRegistryTags.put(resourceKey, networkPayload);
                         return;
                     }
                 }
-                addAndApplyPendingTags(pendingTags, registry, networkPayload);
+                applyTags(registry, networkPayload);
             });
             sendTags = true;
             this.pendingTags = null;
@@ -107,10 +106,10 @@ public class ReplayConfigurationPacketHandler implements ClientConfigurationPack
         if (this.pendingRegistryMap != null && !this.pendingRegistryMap.isEmpty()) {
             if (this.packRepository != null) {
                 try (CloseableResourceManager resourceManager = new MultiPackResourceManager(PackType.SERVER_DATA, this.packRepository.openAllSelected())) {
-                    synchronizeRegistries = tryUpdateRegistries(pendingTags, resourceManager);
+                    synchronizeRegistries = tryUpdateRegistries(resourceManager);
                 }
             } else {
-                synchronizeRegistries = tryUpdateRegistries(pendingTags, ResourceProvider.EMPTY);
+                synchronizeRegistries = tryUpdateRegistries(ResourceProvider.EMPTY);
             }
         }
 
@@ -119,7 +118,7 @@ public class ReplayConfigurationPacketHandler implements ClientConfigurationPack
             // Apply those recorded tags to the registry that remains active so they are not lost.
             synchronizedRegistryTags.forEach((resourceKey, networkPayload) -> {
                 var registry = this.replayServer.registryAccess().lookupOrThrow(resourceKey);
-                addAndApplyPendingTags(pendingTags, registry, networkPayload);
+                applyTags(registry, networkPayload);
             });
         }
 
@@ -133,7 +132,7 @@ public class ReplayConfigurationPacketHandler implements ClientConfigurationPack
             return;
         }
 
-        this.replayServer.updateRegistry(currentFeatureFlags, pendingTags, initialPackets, configurationTasks, this.knownPackIds);
+        this.replayServer.updateRegistry(currentFeatureFlags, initialPackets, configurationTasks, this.knownPackIds);
 
         // Remove all players
         for (ServerPlayer player : new ArrayList<>(this.replayServer.getPlayerList().getPlayers())) {
@@ -150,19 +149,17 @@ public class ReplayConfigurationPacketHandler implements ClientConfigurationPack
         this.replayServer.loadLevel();
     }
 
-    private static <T> void addAndApplyPendingTags(List<Registry.PendingTags<?>> pendingTags, Registry<T> registry,
-                                                   TagNetworkSerialization.NetworkPayload networkPayload) {
+    private static <T> void applyTags(Registry<T> registry, TagNetworkSerialization.NetworkPayload networkPayload) {
         var loadResult = networkPayload.resolve(registry);
         var pending = registry.prepareTagReload(loadResult);
         pending.apply();
-        pendingTags.add(pending);
     }
 
-    private boolean tryUpdateRegistries(List<Registry.PendingTags<?>> pendingTags, ResourceProvider resourceProvider) {
+    private boolean tryUpdateRegistries(ResourceProvider resourceProvider) {
         Map<ResourceKey<? extends Registry<?>>, RegistryDataLoader.NetworkedRegistryData> entries = this.pendingRegistryMap;
         this.pendingRegistryMap = null;
 
-        List<HolderLookup.RegistryLookup<?>> updatedLookups = TagLoader.buildUpdatedLookups(this.replayServer.registryAccess(), pendingTags);
+        List<HolderLookup.RegistryLookup<?>> updatedLookups = TagLoader.buildUpdatedLookups(this.replayServer.registryAccess(), List.of());
 
         RegistryAccess.Frozen synchronizedRegistries;
         try {

--- a/src/main/java/com/moulberry/flashback/playback/ReplayConfigurationPacketHandler.java
+++ b/src/main/java/com/moulberry/flashback/playback/ReplayConfigurationPacketHandler.java
@@ -80,17 +80,23 @@ public class ReplayConfigurationPacketHandler implements ClientConfigurationPack
         }
 
         List<Registry.PendingTags<?>> pendingTags = new ArrayList<>();
+        Map<ResourceKey<? extends Registry<?>>, TagNetworkSerialization.NetworkPayload> synchronizedRegistryTags = new HashMap<>();
 
         if (this.pendingTags != null && !this.pendingTags.isEmpty()) {
             this.pendingTags.forEach((resourceKey, networkPayload) -> {
                 var registry = this.replayServer.registryAccess().lookupOrThrow(resourceKey);
-                var loadResult = networkPayload.resolve(registry);
                 if (this.pendingRegistryMap != null) {
                     var entry = this.pendingRegistryMap.get(resourceKey);
                     if (entry != null) {
+                        // Resolving these tags against the current registry would make resource
+                        // reloads retain its holders. Registry-aware codecs cannot encode those
+                        // holders against the recorded registry, disconnecting replay playback.
                         this.pendingRegistryMap.put(resourceKey, new RegistryDataLoader.NetworkedRegistryData(entry.elements(), networkPayload));
+                        synchronizedRegistryTags.put(resourceKey, networkPayload);
+                        return;
                     }
                 }
+                var loadResult = networkPayload.resolve(registry);
                 pendingTags.add(registry.prepareTagReload(loadResult));
             });
             pendingTags.forEach(Registry.PendingTags::apply);
@@ -108,6 +114,18 @@ public class ReplayConfigurationPacketHandler implements ClientConfigurationPack
             } else {
                 synchronizeRegistries = tryUpdateRegistries(pendingTags, ResourceProvider.EMPTY);
             }
+        }
+
+        if (!synchronizeRegistries) {
+            // A registry is not replaced when its elements are unchanged, even if its tags differ.
+            // Apply those recorded tags to the registry that remains active so they are not lost.
+            synchronizedRegistryTags.forEach((resourceKey, networkPayload) -> {
+                var registry = this.replayServer.registryAccess().lookupOrThrow(resourceKey);
+                var loadResult = networkPayload.resolve(registry);
+                var pending = registry.prepareTagReload(loadResult);
+                pending.apply();
+                pendingTags.add(pending);
+            });
         }
 
         if (synchronizeRegistries) {

--- a/src/main/java/com/moulberry/flashback/playback/ReplayServer.java
+++ b/src/main/java/com/moulberry/flashback/playback/ReplayServer.java
@@ -52,6 +52,7 @@ import net.minecraft.util.Util;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.server.IntegratedServer;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Registry;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.Connection;
 import net.minecraft.network.RegistryFriendlyByteBuf;
@@ -224,7 +225,9 @@ public class ReplayServer extends IntegratedServer {
         return this.metadata;
     }
 
-    public void updateRegistry(FeatureFlagSet featureFlagSet,
+    public List<Registry.PendingTags<?>> overridePendingTags = null;
+
+    public void updateRegistry(FeatureFlagSet featureFlagSet, List<Registry.PendingTags<?>> pendingTags,
                                List<Packet<? super ClientConfigurationPacketListener>> initialPackets,
                                List<ConfigurationTask> configurationTasks,
                                @Nullable Collection<String> knownPackIds) {
@@ -248,6 +251,7 @@ public class ReplayServer extends IntegratedServer {
             ));
         }
 
+        overridePendingTags = pendingTags;
         this.reloadResources(knownPackIds != null ? knownPackIds : this.getPackRepository().getSelectedIds());
 
         this.gamePacketCodec = GameProtocols.CLIENTBOUND_TEMPLATE.bind(RegistryFriendlyByteBuf.decorator(this.registryAccess())).codec();

--- a/src/main/java/com/moulberry/flashback/playback/ReplayServer.java
+++ b/src/main/java/com/moulberry/flashback/playback/ReplayServer.java
@@ -52,7 +52,6 @@ import net.minecraft.util.Util;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.server.IntegratedServer;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Registry;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.Connection;
 import net.minecraft.network.RegistryFriendlyByteBuf;
@@ -225,9 +224,7 @@ public class ReplayServer extends IntegratedServer {
         return this.metadata;
     }
 
-    public List<Registry.PendingTags<?>> overridePendingTags = null;
-
-    public void updateRegistry(FeatureFlagSet featureFlagSet, List<Registry.PendingTags<?>> pendingTags,
+    public void updateRegistry(FeatureFlagSet featureFlagSet,
                                List<Packet<? super ClientConfigurationPacketListener>> initialPackets,
                                List<ConfigurationTask> configurationTasks,
                                @Nullable Collection<String> knownPackIds) {
@@ -251,7 +248,6 @@ public class ReplayServer extends IntegratedServer {
             ));
         }
 
-        overridePendingTags = pendingTags;
         this.reloadResources(knownPackIds != null ? knownPackIds : this.getPackRepository().getSelectedIds());
 
         this.gamePacketCodec = GameProtocols.CLIENTBOUND_TEMPLATE.bind(RegistryFriendlyByteBuf.decorator(this.registryAccess())).codec();


### PR DESCRIPTION
This issue was reported to me:
* https://github.com/mezz/JustEnoughItems/issues/4344
* https://github.com/mezz/JustEnoughItems/issues/4376

It was also reported to your discord here, but without enough information:
* https://discord.com/channels/1257203701349875753/1506633809716838480/1506633809716838480

I was able to reproduce it on Fabric with JEI installed:

1. Run a dedicated Minecraft 1.21.11 server with a server-only datapack with this `pack.mcmeta`:
```
{
  "pack": {
    "description": "Registry mismatch reproduction",
    "min_format": [94, 1],
    "max_format": 94
  }
}
```
2. Add `data/minecraft/trim_pattern/bolt.json`:
```
{
  "asset_id": "minecraft:bolt",
  "decal": true,
  "description": {
    "text": "Server-only Bolt Armor Trim"
  }
}
```
3. Do not install this datapack in the client’s local environment. This creates the required difference:
Server: `minecraft:bolt → literal description, decal=true`
Client: `minecraft:bolt → vanilla translated description, decal=false`
4. Run the client with the broken Flashback build and JEI 27.4.0.24.
5. Connect to the dedicated server and start a Flashback recording.
6. Wait for the player to join fully so the initial snapshot is written.
7. Stop the recording and disconnect from the server.
8. From the client’s replay browser, load the newly created replay.
9. The broken handler resolves the recorded trim-pattern tags against the local vanilla registry. During playback, the vanilla bolt smithing-trim recipe retains the local `minecraft:bolt `holder.
10. JEI registers the vanilla recipe serializers with Fabric recipe synchronization. When Fabric encodes that recipe against the recorded server registry, the local holder has no ID in that registry, and playback disconnects.
